### PR TITLE
Added Content Security Policy meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <!--
+    Customize this policy to fit your own app's needs. For more guidance, see:
+        https://github.com/apache/cordova-plugin-whitelist/blob/master/README.md#content-security-policy
+    Some notes:
+        * gap: is required only on iOS (when using UIWebView) and is needed for JS->native communication
+        * https://ssl.gstatic.com is required only on Android and is needed for TalkBack to function properly
+        * Disables use of inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
+            * Enable inline JS: add 'unsafe-inline' to default-src
+    -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *">
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width">
     <title></title>


### PR DESCRIPTION
Without the gap: parameter, the js context is not able to talk to the native plugins in iOS UIWebView. I discovered this after much frustration and only after seeing the index.html file in a fresh cordova app I created specifically while debugging this issue. It is extremely difficult to find this issue mentioned in any of the online forums and therefore almost impossible to resolve for a beginner. Therefore, I suggest that the csp tag be added in the default starter app to provide some hints that such an issue can exist.
